### PR TITLE
add methods to Extents.extent not GeoInterface.extent

### DIFF
--- a/src/tiles.jl
+++ b/src/tiles.jl
@@ -153,7 +153,7 @@ function Base.iterate(tilegrid::TileGrid, state=1)
 end
 
 "Returns the bounding box of a tile in lng lat"
-function GeoInterface.extent(tile::Tile, crs::WGS84)
+function Extents.extent(tile::Tile, crs::WGS84)
     Z2 = 2^tile.z
 
     ul_lon_deg = tile.x / Z2 * 360.0 - 180.0
@@ -168,7 +168,7 @@ function GeoInterface.extent(tile::Tile, crs::WGS84)
 end
 
 "Get the web mercator bounding box of a tile"
-function GeoInterface.extent(tile::Tile, crs::WebMercator)
+function Extents.extent(tile::Tile, crs::WebMercator)
     tile_size = CE / 2^tile.z
 
     left = tile.x * tile_size - CE / 2
@@ -181,7 +181,7 @@ function GeoInterface.extent(tile::Tile, crs::WebMercator)
 end
 
 "Returns the bounding box of a tile in lng lat"
-function GeoInterface.extent(tilegrid::TileGrid, crs::WGS84)
+function Extents.extent(tilegrid::TileGrid, crs::WGS84)
     Z2 = 2^tilegrid.z
 
     ul_idx = tilegrid.grid[begin]
@@ -201,7 +201,7 @@ function GeoInterface.extent(tilegrid::TileGrid, crs::WGS84)
 end
 
 "Get the web mercator bounding box of a tile"
-function GeoInterface.extent(tilegrid::TileGrid, crs::WebMercator)
+function Extents.extent(tilegrid::TileGrid, crs::WebMercator)
     tile_size = CE / 2^tilegrid.z
 
     ul_idx = tilegrid.grid[begin]

--- a/src/tiles.jl
+++ b/src/tiles.jl
@@ -216,3 +216,7 @@ function Extents.extent(tilegrid::TileGrid, crs::WebMercator)
 
     return Extent(X=(left, right), Y=(bottom, top))
 end
+
+function GeoInterface.extent(tile::Union{Tile, TileGrid}, crs::Union{WGS84, WebMercator})
+    return Extents.extent(tile, crs)
+end


### PR DESCRIPTION
This is the fallback for `GeoInterface.extent` now anyway, and it's confusing to have to use both packages.